### PR TITLE
Fix "No Kerberos credentials available"

### DIFF
--- a/src/ImapMailbox.php
+++ b/src/ImapMailbox.php
@@ -50,7 +50,7 @@ class ImapMailbox
 
     protected function initImapStream()
     {
-        $imapStream = @imap_open($this->imapPath, $this->login, $this->password);
+        $imapStream = @imap_open($this->imapPath, $this->login, $this->password, 0, 0, array('DISABLE_AUTHENTICATOR' => 'GSSAPI'));
         if (!$imapStream) {
             throw new ImapMailboxException('Connection error: ' . imap_last_error());
         }


### PR DESCRIPTION
When using the Symfony3 console to get emails from a windows server, it craches the Symfony error handler!
